### PR TITLE
Support React 17 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/woofers/react-dialog-polyfill#readme",
   "peerDependencies": {
-    "react": "^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0"
+    "react": "^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",


### PR DESCRIPTION
What do you think about marking React v17 as a valid peer dependency? This would help to keep the log of `yarn install` clean.